### PR TITLE
Enhance setTo method to support optional mask

### DIFF
--- a/android/src/main/java/com/adamfreeman/rnocv3/MatManager.java
+++ b/android/src/main/java/com/adamfreeman/rnocv3/MatManager.java
@@ -124,12 +124,24 @@ class MatManager {
         return retArr;
     }
 
-    public static void setTo(int matIndex, ReadableMap cvscalar) {
+    public static void setTo(int matIndex, ReadableMap cvscalar, Integer maskMatIndex) {
         Mat dMat = (Mat)matAtIndex(matIndex);
+        Mat maskMat = null;
+        
+        if (maskMatIndex != null) {
+            maskMat = (Mat)matAtIndex(maskMatIndex);
+        }
+    
         ReadableArray scalarVal = cvscalar.getArray("vals");
-        Scalar dScalar = new Scalar(scalarVal.getDouble(0),scalarVal.getDouble(1),
-          scalarVal.getDouble(2),scalarVal.getDouble(3));
-        dMat.setTo(dScalar);
+        Scalar dScalar = new Scalar(scalarVal.getDouble(0), scalarVal.getDouble(1),
+                                    scalarVal.getDouble(2), scalarVal.getDouble(3));
+    
+        if (maskMat != null) {
+            dMat.setTo(dScalar, maskMat);
+        } else {
+            dMat.setTo(dScalar);
+        }
+        
         setMat(matIndex, dMat);
     }
 

--- a/android/src/main/java/com/adamfreeman/rnocv3/RNOpencv3Module.java
+++ b/android/src/main/java/com/adamfreeman/rnocv3/RNOpencv3Module.java
@@ -184,8 +184,12 @@ public class RNOpencv3Module extends ReactContextBaseJavaModule {
 
     // TODO: not sure if this code should be moved to MatManager
     @ReactMethod
-    public void setTo(ReadableMap mat, ReadableMap cvscalar) {
-        MatManager.getInstance().setTo(mat.getInt("matIndex"), cvscalar);
+    public void setTo(ReadableMap mat, ReadableMap cvscalar, @Nullable ReadableMap maskMat) {
+        if (maskMat != null) {
+            MatManager.getInstance().setTo(mat.getInt("matIndex"), cvscalar, maskMat.getInt("matIndex"));
+        } else {
+            MatManager.getInstance().setTo(mat.getInt("matIndex"), cvscalar, null);
+        }    
     }
 
     // TODO: ditto previous

--- a/mats.js
+++ b/mats.js
@@ -36,10 +36,10 @@ export class Mat {
     return res
   }
 
-  setTo = (color) => {
+  setTo = (color, maskMat) => {
     // of course this could be implemented as a CvInvoke but
     // since it is probably such a common op ...
-    RNOpencv3.setTo(this, color)
+    RNOpencv3.setTo(this, color, maskMat)
   }
 
   get = async(rownum, colnum, data) => {


### PR DESCRIPTION
- Update MatManager's setTo method to accept an optional maskMatIndex parameter.
- Modify the setTo method in RNOpencv3Module to handle the maskMat parameter.
- Adjust the setTo method in mats.js to pass the maskMat to RNOpencv3's setTo method.

This enhancement allows users to apply a mask when setting values in a Mat object.